### PR TITLE
Add timestamp and property to default event

### DIFF
--- a/schemas/com.getground/default/jsonschema/1-0-0
+++ b/schemas/com.getground/default/jsonschema/1-0-0
@@ -22,8 +22,14 @@
         },
         "company_id": {
             "type": ["string", "null"]
+        },
+        "timestamp": {
+            "type": "string"
+        },
+        "property": {
+            "type": ["string", "null"]
         }
     },
-    "required": ["category"],
+    "required": ["category", "timestamp"],
     "additionalProperties": false
 }


### PR DESCRIPTION
Timestamp is needed for when we send events from callbacks using the db record's `created_at` value
Property is needed for status change events so that we can record what the status changed to